### PR TITLE
fix: port and API version will now use default values if none are supplied by the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ config();
 (async (): Promise<void> => {
   let nanoleaf = new Nanoleaf({
     ipAddress: process.env.IP_ADDRESS!,
-    apiVersion: '/api/v1/',
-    port: process.env.PORT!,
     authToken: process.env.AUTH_TOKEN!,
   });
 
@@ -53,7 +51,7 @@ config();
 })();
 ```
 
-Note that this example is loading the IP address, port, and authToken from the environment. This is not required but strongly suggested.
+Note that this example is loading the IP address and authentication token from environment variables using [dotenv](https://github.com/motdotla/dotenv). This is not required but is suggested.
 
 ## Documentation
 
@@ -64,22 +62,22 @@ nanoleaf-ts is composed of six main classes:
 - `effects` - set current effect, get list of available effects, etc.
 - `layout` - general panel layout information
 - `panels` - identification functionality
-- `rhythm` - accessing rhythm module properties
+- `rhythm` - rhythm module functionality
 
 ### Creating the Nanoleaf Object
 
 To start working with the package, create a nanoleaf object similarly to what is shown below.
 
-Pass in the IP address, API version, port, and auth token as strings.
+Pass in the IP address and authentication token as strings.
 
 ```typescript
 import { Nanoleaf } from 'nanoleaf-ts';
 
 let nanoleaf = new Nanoleaf({
   ipAddress: '192.168.1.200', // you can check your router page to find your Aurora's IP
-  apiVersion: '/api/v1/', // you can leave this as is
-  port: '16021', // this is the standard port
   authToken: 'myAuthToken', // you can get this by taking a look at the 'Getting an Auth Token` section
+  apiVersion: '/api/v1/', // optional: uses this value by default
+  port: '16021', // optional: uses this value by default
 });
 ```
 
@@ -149,7 +147,7 @@ let nanoleaf = new Nanoleaf({
     ...
 });
 
-let state = nanoleaf.effects;
+let effects = nanoleaf.effects;
 ```
 
 #### Effects Functions
@@ -180,7 +178,7 @@ let nanoleaf = new Nanoleaf({
     ...
 });
 
-let state = nanoleaf.layout;
+let layout = nanoleaf.layout;
 ```
 
 #### Layout Functions
@@ -204,7 +202,7 @@ let nanoleaf = new Nanoleaf({
     ...
 });
 
-let state = nanoleaf.panels;
+let panels = nanoleaf.panels;
 ```
 
 #### Panels Functions
@@ -220,7 +218,7 @@ let nanoleaf = new Nanoleaf({
     ...
 });
 
-let state = nanoleaf.rhythm;
+let rhythm = nanoleaf.rhythm;
 ```
 
 #### Rhythm Functions

--- a/README.md
+++ b/README.md
@@ -14,7 +14,13 @@ It provides a simple abstraction layer over the Aurora's local-network REST API.
 
 ## Installation
 
+Yarn:
+
 `yarn add nanoleaf-ts`
+
+NPM:
+
+`npm install nanoleaf-ts`
 
 ## Getting an Auth Token
 

--- a/src/__tests__/nanoleaf.test.ts
+++ b/src/__tests__/nanoleaf.test.ts
@@ -8,7 +8,7 @@ const mockedRequest = mocked(Request, true);
 const nanoleaf = new Nanoleaf({
   ipAddress: '192.168.1.19',
   apiVersion: '/api/v1/',
-  port: '50595!',
+  port: '50595',
   authToken: 'randomAuthToken',
 });
 
@@ -52,6 +52,33 @@ mockedRequest.get.mockResolvedValue({
 });
 
 describe('Nanoleaf', () => {
+  test('Should create Nanoleaf instance', () => {
+    let noOptionalArgs = new Nanoleaf({ ipAddress: '/', authToken: '12' });
+    expect(noOptionalArgs).toBeInstanceOf(Nanoleaf);
+
+    let portOnly = new Nanoleaf({
+      ipAddress: '/',
+      authToken: '12',
+      port: '12020',
+    });
+    expect(portOnly).toBeInstanceOf(Nanoleaf);
+
+    let apiVersionOnly = new Nanoleaf({
+      ipAddress: '/',
+      authToken: '12',
+      apiVersion: '/api/v1/',
+    });
+    expect(apiVersionOnly).toBeInstanceOf(Nanoleaf);
+
+    let allArgs = new Nanoleaf({
+      ipAddress: '/',
+      authToken: '12',
+      apiVersion: '/api/v1/',
+      port: '15050',
+    });
+    expect(allArgs).toBeInstanceOf(Nanoleaf);
+  });
+
   test('Should get correct controller info', async () => {
     let fn = await nanoleaf.controllerInfo();
 

--- a/src/__tests__/request.test.ts
+++ b/src/__tests__/request.test.ts
@@ -2,25 +2,12 @@
     Request class integration tests 👍
 */
 
-import Request from '../../request';
+import Request from '../request';
 
 describe('Request.get', () => {
   test('Should throw error when called with https', async () => {
-    let httpsUrl = 'https://jsonplaceholder.typicode.com/todos/1';
+    let httpsUrl = 'https://test.com';
     await expect(Request.get(httpsUrl)).rejects.toThrow();
-  });
-
-  test('Should complete successful GET request', async () => {
-    let httpUrl = 'http://jsonplaceholder.typicode.com/todos/1';
-    let shouldReturn = {
-      userId: 1,
-      id: 1,
-      title: 'delectus aut autem',
-      completed: false,
-    };
-
-    let returnedValue = await Request.get(httpUrl);
-    expect(returnedValue).toEqual(shouldReturn);
   });
 
   test('Should throw error on empty URL', async () => {
@@ -48,12 +35,6 @@ describe('Request.put', () => {
     await expect(Request.put(httpsUrl, exampleBody)).rejects.toThrow();
   });
 
-  test('Should complete successful PUT request', async () => {
-    let httpUrl = 'http://jsonplaceholder.typicode.com/posts/1';
-    let returnedValue = await Request.put(httpUrl, exampleBody);
-    expect(returnedValue).toEqual(exampleBody);
-  });
-
   test('Should throw an error on an invalid status code', async () => {
     // make up a url
     let fakeBody = { idk: 1, someProp: 'hello' };
@@ -64,11 +45,5 @@ describe('Request.put', () => {
   test('Should throw error on empty URL', async () => {
     let emptyUrl = '';
     await expect(Request.put(emptyUrl)).rejects.toThrow();
-  });
-
-  test('Should accept no body', async () => {
-    let httpUrl = 'http://jsonplaceholder.typicode.com/posts/1';
-    let { id } = await Request.put(httpUrl);
-    expect(id).toEqual(1);
   });
 });

--- a/src/interfaces/Nanoleaf.interfaces.ts
+++ b/src/interfaces/Nanoleaf.interfaces.ts
@@ -1,8 +1,8 @@
 export interface NanoleafProperties {
   ipAddress: string;
-  apiVersion: string;
+  apiVersion?: string;
   authToken: string;
-  port: string;
+  port?: string;
 }
 
 export interface OnOffState {

--- a/src/nanoleaf.ts
+++ b/src/nanoleaf.ts
@@ -1,4 +1,4 @@
-import  Request  from './request';
+import Request from './request';
 import {
   NanoleafProperties,
   NanoleafAttributes,
@@ -8,6 +8,49 @@ import { Effects } from './effects';
 import { Layout } from './layout';
 import { Rhythm } from './rhythm';
 import { Panels } from './panels';
+
+// class NanoleafProperties {
+//   private _ipAddress: string;
+//   private _apiVersion: string = '/api/v1/';
+//   private _authToken: string;
+//   private _port: string = '16021';
+
+//   constructor(
+//     ipAddress: string,
+//     apiVersion: string,
+//     authToken: string,
+//     port: string
+//   ) {
+//     this._ipAddress = ipAddress;
+//     this._apiVersion = apiVersion;
+//     this._authToken = authToken;
+//     this._port = port;
+//   }
+
+//   public get ipAddress(): string {
+//     return this._ipAddress;
+//   }
+
+//   public get apiVersion(): string {
+//     return this._apiVersion;
+//   }
+
+//   public get authToken(): string {
+//     return this._authToken;
+//   }
+
+//   public get port(): string {
+//     return this._port;
+//   }
+// }
+
+function provideUserDataDefaults(ud: NanoleafProperties) {
+  let newUserData = { ...ud };
+  if (!newUserData.apiVersion) newUserData.apiVersion = '/api/v1/';
+  if (!newUserData.port) newUserData.port = '16021';
+
+  return newUserData;
+}
 
 export class Nanoleaf {
   private _userData: NanoleafProperties;
@@ -19,7 +62,7 @@ export class Nanoleaf {
   private _panels: Panels;
 
   constructor(userData: NanoleafProperties) {
-    this._userData = userData;
+    this._userData = provideUserDataDefaults(userData);
     this._baseURL = `http://${this._userData.ipAddress}:${this._userData.port}${this._userData.apiVersion}${this._userData.authToken}`;
     this._state = new State(this._baseURL);
     this._effects = new Effects(this._baseURL);

--- a/src/nanoleaf.ts
+++ b/src/nanoleaf.ts
@@ -9,41 +9,6 @@ import { Layout } from './layout';
 import { Rhythm } from './rhythm';
 import { Panels } from './panels';
 
-// class NanoleafProperties {
-//   private _ipAddress: string;
-//   private _apiVersion: string = '/api/v1/';
-//   private _authToken: string;
-//   private _port: string = '16021';
-
-//   constructor(
-//     ipAddress: string,
-//     apiVersion: string,
-//     authToken: string,
-//     port: string
-//   ) {
-//     this._ipAddress = ipAddress;
-//     this._apiVersion = apiVersion;
-//     this._authToken = authToken;
-//     this._port = port;
-//   }
-
-//   public get ipAddress(): string {
-//     return this._ipAddress;
-//   }
-
-//   public get apiVersion(): string {
-//     return this._apiVersion;
-//   }
-
-//   public get authToken(): string {
-//     return this._authToken;
-//   }
-
-//   public get port(): string {
-//     return this._port;
-//   }
-// }
-
 function provideUserDataDefaults(ud: NanoleafProperties) {
   let newUserData = { ...ud };
   if (!newUserData.apiVersion) newUserData.apiVersion = '/api/v1/';


### PR DESCRIPTION
`port: '16021'`
`apiVersion: '/api/v1/`